### PR TITLE
Coding interviews minor adjustments (#86)

### DIFF
--- a/src/pages/coding-interviews.js
+++ b/src/pages/coding-interviews.js
@@ -391,9 +391,9 @@ class Technical extends React.Component {
                     to participate in one-on-one mock technical coding interviews
                      with fellow students and alumni who have interned at Microsoft, Facebook, Google and more.  
                     These 1 hour interview sessions will allow you to pratice real technical interview questions while connecting with a fellow Columbia student.</p>
-                    <p style={{fontSize : "15px", textAlign: "left",  marginRight: "10px"}}><strong>Interested in giving mock interviews?</strong> Email us at 
-                    <a style={{ color: "#0072CE", display: "inline-block", paddingLeft: "0.3%" }}
-                 href={"mailto:columbiavirtualcampus@gmail.com"}> columbiavirtualcampus@gmail.com</a>!</p>
+                    <p style={{fontSize : "18px", textAlign: "left",  marginRight: "10px"}}><strong>Interested in giving mock interviews?</strong> Please fill out this 
+                    <a style={{ color: "#0072CE", display: "inline-block", paddingLeft: "0.3%" }} target="_blank"
+                 href={"https://docs.google.com/forms/d/e/1FAIpQLSfc5yiAoceGTiaKIvqYNTw5kXCfn_wwgAP3C27DJpgqpnvaSQ/viewform"}>form</a>!</p>
                 </GridItem>
         </GridContainer>
         <div style={{ color: "#F1945B", backgroundColor: "#F1945B", height: 3}}/>
@@ -403,7 +403,6 @@ class Technical extends React.Component {
           <Calendar
             views={["month", "week", "day"]}
             localizer={localizer}
-            defaultDate={new Date('August 3, 2020 0:00:00')}
             events={this.state.myEventsList}
             defaultView={"week"}
             startAccessor="start_date"


### PR DESCRIPTION
* Add max weekly interviews checks

* Coding interview page UI adjustments

* Fixed weekly check in rendering calendar

* Added loading bar to calendar

* increase signup cap to 3

* Fix resume link overflow issue

* Oepn resume link in new tab

* Add UI check that greys out events that are two days away from current date

* Add a check if user signs up for a time less than 2 days before the time

* Cleaned up tooSoon check + new replyTo

* Changed email to the link

* Remove default date from calendar

Co-authored-by: Riya Saha <rs3796@barnard.edu>
Co-authored-by: Ainur Kaishibayeva <ainur@Ainurs-MBP.lan>